### PR TITLE
Using binary regex for findall function in _read_doc_text_strings

### DIFF
--- a/vipermonkey/vmonkey.py
+++ b/vipermonkey/vmonkey.py
@@ -256,7 +256,7 @@ def _read_doc_text_strings(data):
     """
 
     # Pull strings from doc.
-    str_list = re.findall("[^\x00-\x1F\x7F-\xFF]{4,}", data)
+    str_list = re.findall(b"[^\x00-\x1F\x7F-\xFF]{4,}", data)
     r = []
     for s in str_list:
         r.append(s)


### PR DESCRIPTION
I was using the process_file function in my analysis here, and I noticed the code was crashing at this point because data is a binary content, so you need to handle it using a binary encoded regex.